### PR TITLE
Add golangci-lint support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,27 @@
 ---
 kind: pipeline
+name: Lint
+platform:
+  os: linux
+  arch: amd64
+trigger:
+  event:
+    - push
+    - pull_request
+    - tag
+  ref:
+    - refs/heads/main
+    - refs/pull/*/head
+    - refs/tags/**
+
+steps:
+  - name: lint
+    image: golangci/golangci-lint:v1.44
+    commands:
+      - apt-get update -y && apt-get install -y libsystemd-dev
+      - make DOCKER_OPTS="" lint
+---
+kind: pipeline
 type: docker
 name: Release
 platform:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,83 @@
+# Full list of configuration options: https://golangci-lint.run/usage/configuration/
+
+run:
+  timeout: 5m
+
+output:
+  sort-results: true
+
+linters:
+  enable:
+    - deadcode    # Report on unused code
+    - errcheck    # Report unchecked errors
+    - goconst     # Find repeated strings that could be replaced by constant
+    - gofmt       # Check whether code was gofmt-ed
+    - goimports   # Check imports were formatted with gofmt
+    - revive      # Broad set of rules; replaces deprecated golint
+    - gosimple    # Check whether code can be simplified
+    - ineffassign # Detect when assignment to variable is never used
+    - misspell    # Report on commonly misspelled English words
+    - structcheck # Report on unused struct fields
+    - unconvert   # Remove unnecessary type conversions
+    - unparam     # Detect unused function parameters
+    - varcheck    # Find unused global variables/constants
+    - govet       # `go vet`
+    - unused      # Detect unused constants/variables/functions/types
+    - typecheck   # Ensure code typechecks
+    - depguard    # Allow/denylist specific imports
+    - makezero    # Detect misuse of make with non-zero length and append
+    - tenv        # Use testing.(*T).Setenv instead of os.Setenv
+    - whitespace  # Report unnecessary blank lines
+
+issues:
+  # We want to use our own exclusion rules and ignore all the defaults.
+  exclude-use-default: false
+
+  exclude-rules:
+    # It's fine if tests ignore errors.
+    - path: _test.go
+      linters:
+        - errcheck
+
+  exclude:
+    # Ignoring errors on Close, Log, and removing files is OK in most cases.
+    - "Error return value of `(.*\\.Close|.*\\.Log|os.Remove)` is not checked"
+    # Packages for integrations are named matching their upstream counterpart,
+    # which almost always have underscores.
+    - "var-naming: don't use an underscore in package name"
+
+# Linter settings options: https://golangci-lint.run/usage/linters/
+linters-settings:
+  depguard:
+    # We want to report errors on stdlib packages, not just third party modules
+    include-go-root: true
+
+    packages-with-error-message:
+      - sync/atomic: "Use go.uber.org/atomic instead of sync/atomic"
+      - github.com/pkg/errors: "Use errors instead of github.com/pkg/errors"
+      - github.com/go-kit/kit/log: "Use github.com/go-kit/log instead of github.com/go-kit/kit/log"
+      - golang.org/x/sync/errgroup: "Use github.com/oklog/run instead of golang.org/x/sync/errgroup"
+
+  whitespace:
+    # While there normally shouldn't be extra redundant leading/trailing
+    # whitespace, if statement conditions and function headers that cross
+    # multiple lines are an exception.
+    #
+    #   if true ||
+    #      false {
+    #
+    #       // ... ^ must have empty line above
+    #    }
+    #
+    #   func foo(
+    #     a int,
+    #   ) {
+    #
+    #     // ... ^ must have empty line above
+    #   }
+    #
+    # This helps readers easily separate where the multi-line if/function ends
+    # at a glance.
+    multi-if: true
+    multi-func: true
+

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,7 @@ release: build
 .PHONY: drone
 drone:
 	drone sign --save grafana/vmware_exporter
+
+.PHONY: lint
+lint:
+	golangci-lint run -v --timeout=10m

--- a/vsphere/collector.go
+++ b/vsphere/collector.go
@@ -107,6 +107,7 @@ func (c *vsphereCollector) collectResource(ctx context.Context, metrics chan<- p
 			defer ccWg.Done()
 			if sampleTime := c.collectChunk(ctx, metrics, cli, spec, chunk); sampleTime != nil &&
 				sampleTime.After(latestSample) && !sampleTime.IsZero() {
+
 				latestSample = *sampleTime
 			}
 		}(refs[i:end])
@@ -119,6 +120,7 @@ func (c *vsphereCollector) collectResource(ctx context.Context, metrics chan<- p
 
 func (c *vsphereCollector) collectChunk(ctx context.Context, metrics chan<- prometheus.Metric, cli *client,
 	spec types.PerfQuerySpec, chunk []types.ManagedObjectReference) *time.Time {
+
 	defer func() {
 		c.sem.Release(1)
 	}()
@@ -160,7 +162,7 @@ func (c *vsphereCollector) collect(ctx context.Context, cli *client, spec types.
 	}
 
 	for _, metric := range result {
-		name := strings.Split(fmt.Sprintf("%s", metric.Entity), ":")[1]
+		name := strings.Split(metric.Entity.String(), ":")[1]
 		level.Debug(c.logger).Log("name", name)
 		for _, v := range metric.Value {
 			counter := counters[v.Name]

--- a/vsphere/config.go
+++ b/vsphere/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/vmware/govmomi/vim25/soap"
 )
 
+// Config represents needed config structure for vSphere exporter
 type Config struct {
 	ListenAddr              string
 	TelemetryPath           string
@@ -45,6 +46,7 @@ func (v soapURLFlag) Set(s string) error {
 	return nil
 }
 
+// RegisterFlags register the flag params for the exporter
 func (c *Config) RegisterFlags(fs *flag.FlagSet) {
 	// Exporter web configs
 	{
@@ -67,5 +69,4 @@ func (c *Config) RegisterFlags(fs *flag.FlagSet) {
 		fs.IntVar(&c.ChunkSize, "vsphere.mo-chunk-size", defaultConfig.ChunkSize,
 			"Managed object reference chunk size to use when fetching from vSphere.")
 	}
-
 }

--- a/vsphere/endpoint.go
+++ b/vsphere/endpoint.go
@@ -316,7 +316,7 @@ func (e *endpoint) getAncestorName(ctx context.Context, client *client, resource
 			path = append(path, here.Reference().String())
 			o := object.NewCommon(client.Client.Client, r)
 			var result mo.ManagedEntity
-			ctx1, cancel1 := context.WithTimeout(ctx, time.Duration(e.cfg.Timeout))
+			ctx1, cancel1 := context.WithTimeout(ctx, e.cfg.Timeout)
 			defer cancel1()
 			err := o.Properties(ctx1, here, []string{"parent", "name"}, &result)
 			if err != nil {
@@ -465,6 +465,7 @@ func getVMs(ctx context.Context, e *endpoint, resourceFilter *resourceFilter) (o
 				for _, ipType := range e.cfg.IPAddresses {
 					if !(ipType == "ipv4" && isIPv4.MatchString(addr) ||
 						ipType == "ipv6" && isIPv6.MatchString(addr)) {
+
 						continue
 					}
 

--- a/vsphere/exporter.go
+++ b/vsphere/exporter.go
@@ -2,20 +2,23 @@ package vsphere
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/exporter-toolkit/web"
-	"net/http"
 )
 
+// Exporter holds the data needed to run a vSphere exporter
 type Exporter struct {
 	cfg    *Config
 	logger log.Logger
 	server *http.Server
 }
 
+// NewExporter creates a new vSphere exporter from the given config
 func NewExporter(logger log.Logger, cfg *Config) (*Exporter, error) {
 	ctx := context.Background()
 	x := &Exporter{
@@ -60,6 +63,7 @@ func NewExporter(logger log.Logger, cfg *Config) (*Exporter, error) {
 	return x, nil
 }
 
+// Start runs the exporter
 func (e *Exporter) Start() error {
 	level.Debug(e.logger).Log("msg", "starting the server")
 	defer level.Debug(e.logger).Log("msg", "server stopped")

--- a/vsphere/finder.go
+++ b/vsphere/finder.go
@@ -2,12 +2,13 @@ package vsphere
 
 import (
 	"context"
+	"reflect"
+	"strings"
+
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/view"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"reflect"
-	"strings"
 )
 
 var (
@@ -77,6 +78,7 @@ func (f *finder) findResources(ctx context.Context, resType, path string, objs m
 
 func (f *finder) descend(ctx context.Context, root types.ManagedObjectReference, resType string,
 	tokens []property.Filter, pos int, objs map[string]types.ObjectContent) error {
+
 	isLeaf := pos == len(tokens)-1
 
 	// No more tokens to match?


### PR DESCRIPTION
Added `golanci-lint` support to the pipeline. This fixes #18.
The config is taken from the Agent repo.

I fixed some lint issues but I keept the following:
```
vsphere/client.go:45:2: `closeGate` is unused (structcheck)
	closeGate sync.Once
	^
vsphere/endpoint.go:41:2: `pKey` is unused (structcheck)
	pKey             string
	^
vsphere/endpoint.go:42:2: `parentTag` is unused (structcheck)
	parentTag        string
	^
vsphere/endpoint.go:51:2: `parent` is unused (structcheck)
	parent           string
	^
vsphere/endpoint.go:53:2: `lastColl` is unused (structcheck)
	lastColl         time.Time
	^
vsphere/endpoint.go:68:80: newEndpoint - result 1 (error) is always nil (unparam)
func newEndpoint(cfg *vSphereConfig, url *url.URL, log log.Logger) (*endpoint, error) {
                                                                               ^
vsphere/vsphere.go:33:2: `cancel` is unused (structcheck)
	cancel context.CancelFunc
```

@rlankfo maybe you want to look at them as I don't have much context.