### PR TITLE
update name and mo labels

### DIFF
--- a/vsphere/collector.go
+++ b/vsphere/collector.go
@@ -176,18 +176,16 @@ func (c *vsphereCollector) collect(ctx context.Context, cli *client, spec types.
 	)
 
 	for _, metric := range result {
-		name := strings.Split(metric.Entity.String(), ":")[1]
-		level.Debug(c.logger).Log("name", name)
+		mo := strings.Split(metric.Entity.String(), ":")[1]
 
-		// create desc
 		constLabels := make(prometheus.Labels)
-		constLabels["name"] = name
+		constLabels["mo"] = mo
+		constLabels["name"] = c.endpoint.resourceKinds[res.name].objects[mo].name
 
 		// add type/parent labels
-		parent = c.endpoint.resourceKinds[res.name].objects[name].parentRef.Value
+		parent = c.endpoint.resourceKinds[res.name].objects[mo].parentRef.Value
 		parentType = res.parent
 		for parent != "" {
-			// get parent name
 			if pRes, ok := c.endpoint.resourceKinds[parentType]; ok {
 				if pObj := pRes.objects[parent]; pObj != nil {
 					constLabels[parentType] = pObj.name

--- a/vsphere/collector.go
+++ b/vsphere/collector.go
@@ -179,7 +179,7 @@ func (c *vsphereCollector) collect(ctx context.Context, cli *client, spec types.
 		mo := strings.Split(metric.Entity.String(), ":")[1]
 
 		constLabels := make(prometheus.Labels)
-		constLabels["mo"] = mo
+		constLabels["moid"] = mo
 		constLabels["name"] = c.endpoint.resourceKinds[res.name].objects[mo].name
 
 		// add type/parent labels


### PR DESCRIPTION
This PR changes the "name" label to be the actual resource name, instead of the managed object name.

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/364801/181403341-96f9b525-1c60-45e7-9f54-e7e0f6700a24.png">

<img width="1021" alt="image" src="https://user-images.githubusercontent.com/364801/181403392-0d20ddfe-a39c-49dd-acb0-2f948844e862.png">
