### PR TITLE
add flag for CollectConcurrency

### DIFF
--- a/vsphere/config.go
+++ b/vsphere/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	TelemetryPath           string
 	TLSConfigPath           string
 	ChunkSize               int
+	CollectConcurrency      int
 	VSphereURL              *url.URL
 	ObjectDiscoveryInterval time.Duration
 	EnableExporterMetrics   bool
@@ -24,6 +25,7 @@ var defaultConfig = &Config{
 	TelemetryPath:           "/metrics",
 	TLSConfigPath:           "",
 	ChunkSize:               5,
+	CollectConcurrency:      8,
 	ObjectDiscoveryInterval: 0,
 	EnableExporterMetrics:   false,
 }
@@ -70,6 +72,9 @@ func (c *Config) RegisterFlags(fs *flag.FlagSet) {
 			"Object discovery duration interval. Discovery will occur per scrape if set to 0.")
 		fs.IntVar(&c.ChunkSize, "vsphere.mo-chunk-size", defaultConfig.ChunkSize,
 			"Managed object reference chunk size to use when fetching from vSphere.")
+		fs.IntVar(&c.CollectConcurrency, "vsphere.concurrent-requests",
+			defaultConfig.CollectConcurrency,
+			"The number of concurrent requests to make while fetching metrics from vSphere.")
 	}
 
 	// Misc configs

--- a/vsphere/exporter.go
+++ b/vsphere/exporter.go
@@ -78,6 +78,7 @@ func NewExporter(logger log.Logger, cfg *Config) (*Exporter, error) {
 		Addr:    cfg.ListenAddr,
 		Handler: topMux,
 	}
+
 	return x, nil
 }
 
@@ -87,6 +88,12 @@ func (e *Exporter) Start() error {
 	defer level.Debug(e.logger).Log("msg", "server stopped")
 	return web.ListenAndServe(e.server, e.cfg.TLSConfigPath, log.With(e.logger, "component", "web"))
 }
+
+func (e *Exporter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	e.server.Handler.ServeHTTP(w, r)
+}
+
+var _ http.Handler = (*Exporter)(nil)
 
 type handler struct {
 	logger      log.Logger

--- a/vsphere/exporter.go
+++ b/vsphere/exporter.go
@@ -35,6 +35,9 @@ func NewExporter(logger log.Logger, cfg *Config) (*Exporter, error) {
 	registry := prometheus.NewRegistry()
 	defaultVSphere.ObjectDiscoveryInterval = cfg.ObjectDiscoveryInterval
 	defaultVSphere.RefChunkSize = cfg.ChunkSize
+	if cfg.CollectConcurrency > 0 {
+		defaultVSphere.CollectConcurrency = cfg.CollectConcurrency
+	}
 
 	var e *endpoint
 	if cfg.EnableExporterMetrics {


### PR DESCRIPTION
This PR adds a flag to make `CollectConcurrency` configurable. It also exposes a `ServeHTTP` method on the `Exporter` to integrate into the agent.